### PR TITLE
Ignore tmux (centos process)

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ var CommitString string
 var exceptByParent = map[string]struct{}{
 	"screen":       {},
 	"tmux: server": {},
+	"tmux":         {},
 }
 
 var exceptByName = map[string]struct{}{


### PR DESCRIPTION
In centos, the tmux process is named `tmux`, not `tmux: server`